### PR TITLE
Gracefully handle 404 when removing container

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -517,7 +517,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
         String url = urlBuilder.removeContainer(containerId, removeVolumes);
         log.verbose(Logger.LogVerboseCategory.API, API_LOG_FORMAT_DELETE, url);
         try {
-            delegate.delete(url, HTTP_NO_CONTENT);
+            delegate.delete(url, HTTP_NO_CONTENT, HTTP_NOT_FOUND);
         } catch (IOException e) {
             throw new DockerAccessException(e, "Unable to remove container [%s]", containerId);
         }


### PR DESCRIPTION
If a container is to be removed - yet doesn't exist anymore, we can gracefully handle the 404 by treating it as though the container had been removed.